### PR TITLE
Add Jest and server test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Mini Game Tournament
+
+## Running Backend Tests
+
+The backend uses **Jest** for testing. To execute the test suite:
+
+```bash
+cd backend
+npm test
+```
+
+This starts the Jest runner which launches the server defined in `index.js` and verifies it can listen on a port.

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,26 @@
+const http = require('http');
+const { Server } = require('socket.io');
+
+const httpServer = http.createServer();
+const io = new Server(httpServer);
+
+function startServer(port = process.env.PORT || 3000) {
+  return new Promise((resolve, reject) => {
+    httpServer.listen(port, () => resolve(httpServer));
+    httpServer.on('error', reject);
+  });
+}
+
+function closeServer() {
+  return new Promise((resolve, reject) => {
+    httpServer.close(err => (err ? reject(err) : resolve()));
+  });
+}
+
+if (require.main === module) {
+  startServer().then(server => {
+    console.log(`Server listening on port ${server.address().port}`);
+  });
+}
+
+module.exports = { startServer, closeServer, httpServer };

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
@@ -11,5 +11,8 @@
   "description": "",
   "dependencies": {
     "socket.io": "^4.8.1"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
   }
 }

--- a/backend/test/index.test.js
+++ b/backend/test/index.test.js
@@ -1,0 +1,10 @@
+const { startServer, closeServer, httpServer } = require('../index');
+
+describe('server', () => {
+  test('starts and listens on a port', async () => {
+    await startServer(0); // let OS assign a free port
+    const addr = httpServer.address();
+    expect(addr && addr.port).toBeGreaterThan(0);
+    await closeServer();
+  });
+});


### PR DESCRIPTION
## Summary
- install jest test framework in `backend`
- add simple socket.io server implementation
- create a basic Jest test to start and stop the server
- document how to run backend tests

## Testing
- `npm test` *(fails: jest not found)*